### PR TITLE
Correct parsing of html strings

### DIFF
--- a/src/app/Services/LangFiles.php
+++ b/src/app/Services/LangFiles.php
@@ -184,7 +184,7 @@ class LangFiles
      */
     private function sanitize($str)
     {
-        return e(trim($str));
+        return trim($str);
     }
 
     /**

--- a/src/resources/views/language_inputs.blade.php
+++ b/src/resources/views/language_inputs.blade.php
@@ -7,10 +7,11 @@ echo Form::label($key, str_replace(['_', '-'], ' ', $key), array('class' => 'col
 			<?php
 			if (count($parents)) {
 				$parents_array = implode('.', $parents);
-				echo trans($lang_file_name.'.'.$parents_array.'.'.$key);
+				$string_text = trans($lang_file_name . '.' . $parents_array . '.' . $key);
 			} else {
-				echo trans($lang_file_name.'.'.$key);
+				$string_text = trans($lang_file_name . '.' .$key);
 			}
+			echo htmlentities($string_text);
 			?>
 		</div>
 	</div>


### PR DESCRIPTION
Two changes:
1. The translation page display escaped html tags instead of put them as page markup.
2. Saving a translation containing html doesn't escape the tags to allow the user to save right translation for html strings.
