### PR TITLE
don't require all fields to be populated

### DIFF
--- a/src/app/Http/Controllers/LanguageCrudController.php
+++ b/src/app/Http/Controllers/LanguageCrudController.php
@@ -147,15 +147,12 @@ class LanguageCrudController extends CrudController
 
         $langfile->setFile($file);
 
-        $fields = $langfile->testFields($request->all());
-        if (empty($fields)) {
-            if ($langfile->setFileContent($request->all())) {
-                \Alert::success(trans('backpack::langfilemanager.saved'))->flash();
-                $status = true;
-            }
+        if ($langfile->setFileContent($request->all())) {
+            \Alert::success(trans('backpack::langfilemanager.saved'))->flash();
+            $status = true;
         } else {
             $message = trans('admin.language.fields_required');
-            \Alert::error(trans('backpack::langfilemanager.please_fill_all_fields'))->flash();
+            \Alert::error(trans('backpack::langfilemanager.file_could_not_be_saved'))->flash();
         }
 
         return redirect()->back();


### PR DESCRIPTION
Hey,

For my use-case I needed to change the behaviour of saving translations.

Our translators are starting with an empty translation and are incrementally adding new strings. As from my point of view "a little bit translated" is better then "nothing translated", I was wondering what was the thinking behind this validation.