### PR TITLE
sort translationsKeys before saving

### DIFF
--- a/src/app/Services/LangFiles.php
+++ b/src/app/Services/LangFiles.php
@@ -175,6 +175,8 @@ class LangFiles
             $this->setArrayValue($returnArray, $keys, $value);
         }
 
+        ksort($returnArray);
+        
         return $returnArray;
     }
 

--- a/src/app/Services/LangFiles.php
+++ b/src/app/Services/LangFiles.php
@@ -176,7 +176,6 @@ class LangFiles
         }
 
         ksort($returnArray);
-        
         return $returnArray;
     }
 


### PR DESCRIPTION
Hey,

at least for me, all keys are being shuffled after an editor saves a translation. When they make multiple changes, that is very confusing. To maintain any specific order, I sorted the translations by their keyname.