### PR TITLE
Support Tabs for langueange file layers and plural forms

### DIFF
--- a/src/app/Services/LangFiles.php
+++ b/src/app/Services/LangFiles.php
@@ -137,7 +137,7 @@ class LangFiles
         $has_lower_level = false;
         $first_key = array_key_first($fileArray);
         foreach ($fileArray as $key => $item) {
-            if (is_array($item))  {
+            if (is_array($item)) {
                 $has_lower_level = true;
             }
         }
@@ -151,7 +151,7 @@ class LangFiles
                 'lang_file_name' => $this->file,
                 'fileArray'=>$fileArray,
             ])->render();
-        }else{
+        } else {
             foreach ($fileArray as $key => $item) {
                 echo view()->make('langfilemanager::language_inputs', [
                     'key' => $key,

--- a/src/app/Services/LangFiles.php
+++ b/src/app/Services/LangFiles.php
@@ -137,9 +137,11 @@ class LangFiles
         $has_lower_level = false;
         $first_key = array_key_first($fileArray);
         foreach ($fileArray as $key => $item) {
-            if (is_array($item))  $has_lower_level = true;
+            if (is_array($item))  {
+                $has_lower_level = true;
+            }
         }
-        if ($has_lower_level){
+        if ($has_lower_level) {
             echo view()->make('langfilemanager::language_tabs', [
                 'first_key'=>$first_key,
                 'header' => $key,
@@ -147,16 +149,16 @@ class LangFiles
                 'level' => $level,
                 'langfile' => $this,
                 'lang_file_name' => $this->file,
-                'fileArray'=>$fileArray
+                'fileArray'=>$fileArray,
             ])->render();
         }else{
             foreach ($fileArray as $key => $item) {
-                    echo view()->make('langfilemanager::language_inputs', [
-                        'key' => $key,
-                        'item' => $item,
-                        'parents' => $parents,
-                        'lang_file_name' => $this->file,
-                    ])->render();
+                echo view()->make('langfilemanager::language_inputs', [
+                    'key' => $key,
+                    'item' => $item,
+                    'parents' => $parents,
+                    'lang_file_name' => $this->file,
+                ])->render();
             }
         }
     }

--- a/src/app/Services/LangFiles.php
+++ b/src/app/Services/LangFiles.php
@@ -134,23 +134,29 @@ class LangFiles
         if ($parent) {
             $parents[] = $parent;
         }
+        $has_lower_level = false;
+        $first_key = array_key_first($fileArray);
         foreach ($fileArray as $key => $item) {
-            if (is_array($item)) {
-                echo view()->make('langfilemanager::language_headers', [
-                    'header' => $key,
-                    'parents' => $parents,
-                    'level' => $level,
-                    'item' => $item,
-                    'langfile' => $this,
-                    'lang_file_name' => $this->file,
-                ])->render();
-            } else {
-                echo view()->make('langfilemanager::language_inputs', [
-                    'key' => $key,
-                    'item' => $item,
-                    'parents' => $parents,
-                    'lang_file_name' => $this->file,
-                ])->render();
+            if (is_array($item))  $has_lower_level = true;
+        }
+        if ($has_lower_level){
+            echo view()->make('langfilemanager::language_tabs', [
+                'first_key'=>$first_key,
+                'header' => $key,
+                'parents' => $parents,
+                'level' => $level,
+                'langfile' => $this,
+                'lang_file_name' => $this->file,
+                'fileArray'=>$fileArray
+            ])->render();
+        }else{
+            foreach ($fileArray as $key => $item) {
+                    echo view()->make('langfilemanager::language_inputs', [
+                        'key' => $key,
+                        'item' => $item,
+                        'parents' => $parents,
+                        'lang_file_name' => $this->file,
+                    ])->render();
             }
         }
     }

--- a/src/resources/views/language_headers.blade.php
+++ b/src/resources/views/language_headers.blade.php
@@ -1,10 +1,8 @@
 <div style="margin-left: {{ (15 * ($level - 1)) }}px">
-	{{--
 	<h4>
 		{!! /*$level.*/ucfirst(str_replace(['_', '-'], ' ', trim($header))) !!}
 		<a class="toggle-inputs" href="#"><i class="glyphicon glyphicon-plus-sign"></i></a>
 	</h4>
-	--}}
 	<div class="lang-input-box" style="margin-left: 10px;">
 		{!! $langfile->displayInputs($item, $parents, $header, $level) !!}
 	</div>

--- a/src/resources/views/language_headers.blade.php
+++ b/src/resources/views/language_headers.blade.php
@@ -1,8 +1,10 @@
 <div style="margin-left: {{ (15 * ($level - 1)) }}px">
+	{{--
 	<h4>
 		{!! /*$level.*/ucfirst(str_replace(['_', '-'], ' ', trim($header))) !!}
 		<a class="toggle-inputs" href="#"><i class="glyphicon glyphicon-plus-sign"></i></a>
 	</h4>
+	--}}
 	<div class="lang-input-box" style="margin-left: 10px;">
 		{!! $langfile->displayInputs($item, $parents, $header, $level) !!}
 	</div>

--- a/src/resources/views/language_inputs.blade.php
+++ b/src/resources/views/language_inputs.blade.php
@@ -20,21 +20,34 @@
 			@endphp
 
 			<div style="margin-left: 15px;">
+				<ul class="nav nav-tabs" >
+					@foreach ($chuncks as $k => $chunck)
+						<li class="nav-item">
+							<a class="nav-link" data-toggle="tab" data-target="#{{$key.'-'.$k}}">{{ (!$k ? trans('admin.language.singular') : trans('admin.language.plural')).":" }}</a>
+						</li>
+					@endforeach
+				</ul>
+				<div class="tab-content">
 			@foreach ($chuncks as $k => $chunck)
 				@php
 				preg_match('/^({\w}|\[[\w,]+\])([\w\s:]+)/', trim($chunck), $m);
 				@endphp
 				@if (empty($m))
-					<label for="{{ $chunck }}" class="col-sm-2 control-label">{{ (!$k ? trans('admin.language.singular') : trans('admin.language.plural')).":" }}</label>
+					<div class="tab-pane "  id="{{$key.'-'.$k}}">
+					 {{-- <label for="{{ $chunck }}" class="col-sm-2 control-label">{{ (!$k ? trans('admin.language.singular') : trans('admin.language.plural')).":" }}</label>--}}
 					<textarea name="{{ (empty($parents) ? $key : implode('__', $parents)."__{$key}")."[after][]" }}" class="form-control" rows="2"> {{ $chunck }} </textarea>
 					<br>
+					</div>
 				@else
+					<div class="tab-pane "  id="{{$key.'-'.$k}}">
 					<label for="{{ $chunck }}" class="col-sm-2 control-label">{{ (!$k ? trans('admin.language.singular') : trans('admin.language.plural'))." ($m[1]):" }}</label>
 					<input type="hidden" name="{{ (empty($parents) ? $key : implode('__', $parents)."__{$key}")."[before][]" }}" value="{{ $m[1] }}">
 					<textarea name="{{ (empty($parents) ? $key : implode('__', $parents)."__{$key}")."[after][]" }}" class="form-control" rows="2"> {{ $m[2] }} </textarea>
 					<br>
+					</div>
 				@endif
 			@endforeach
+				</div>
 			</div>
 		@else
 			<textarea name="{{ (empty($parents) ? $key : implode('__', $parents)."__{$key}") }}" class="form-control" rows="2"> {{ $item }} </textarea>

--- a/src/resources/views/language_inputs.blade.php
+++ b/src/resources/views/language_inputs.blade.php
@@ -22,31 +22,34 @@
 			<div style="margin-left: 15px;">
 				<ul class="nav nav-tabs" >
 					@foreach ($chuncks as $k => $chunck)
+                        @php
+				        preg_match('/^({\w}|\[[\w,]+\])([\w\s:]+)/', trim($chunck), $m);
+				        @endphp
 						<li class="nav-item">
-							<a class="nav-link" data-toggle="tab" data-target="#{{$key.'-'.$k}}">{{ (!$k ? trans('admin.language.singular') : trans('admin.language.plural')).":" }}</a>
-						</li>
+                            @if (empty($m))
+							    <a class="nav-link" data-toggle="tab" data-target="#{{$key.'-'.$k}}">{{ (!$k ? trans('admin.language.singular') : trans('admin.language.plural')).":" }}</a>
+						    @else
+                                <a class="nav-link" data-toggle="tab" data-target="#{{$key.'-'.$k}}">{{ (!$k ? trans('admin.language.singular') : trans('admin.language.plural'))." ($m[1]):"  }}</a>
+                            @endif
+                        </li>
 					@endforeach
 				</ul>
 				<div class="tab-content">
-			@foreach ($chuncks as $k => $chunck)
-				@php
-				preg_match('/^({\w}|\[[\w,]+\])([\w\s:]+)/', trim($chunck), $m);
-				@endphp
-				@if (empty($m))
-					<div class="tab-pane "  id="{{$key.'-'.$k}}">
-					 {{-- <label for="{{ $chunck }}" class="col-sm-2 control-label">{{ (!$k ? trans('admin.language.singular') : trans('admin.language.plural')).":" }}</label>--}}
-					<textarea name="{{ (empty($parents) ? $key : implode('__', $parents)."__{$key}")."[after][]" }}" class="form-control" rows="2"> {{ $chunck }} </textarea>
-					<br>
-					</div>
-				@else
-					<div class="tab-pane "  id="{{$key.'-'.$k}}">
-					<label for="{{ $chunck }}" class="col-sm-2 control-label">{{ (!$k ? trans('admin.language.singular') : trans('admin.language.plural'))." ($m[1]):" }}</label>
-					<input type="hidden" name="{{ (empty($parents) ? $key : implode('__', $parents)."__{$key}")."[before][]" }}" value="{{ $m[1] }}">
-					<textarea name="{{ (empty($parents) ? $key : implode('__', $parents)."__{$key}")."[after][]" }}" class="form-control" rows="2"> {{ $m[2] }} </textarea>
-					<br>
-					</div>
-				@endif
-			@endforeach
+                    @foreach ($chuncks as $k => $chunck)
+                        @php
+                        preg_match('/^({\w}|\[[\w,]+\])([\w\s:]+)/', trim($chunck), $m);
+                        @endphp
+                        @if (empty($m))
+                            <div class="tab-pane "  id="{{$key.'-'.$k}}">
+                                <textarea name="{{ (empty($parents) ? $key : implode('__', $parents)."__{$key}")."[after][]" }}" class="form-control" rows="2"> {{ $chunck }} </textarea>
+                            </div>
+                        @else
+                            <div class="tab-pane "  id="{{$key.'-'.$k}}">
+                                <input type="hidden" name="{{ (empty($parents) ? $key : implode('__', $parents)."__{$key}")."[before][]" }}" value="{{ $m[1] }}">
+                                <textarea name="{{ (empty($parents) ? $key : implode('__', $parents)."__{$key}")."[after][]" }}" class="form-control" rows="2"> {{ $m[2] }} </textarea>
+                            </div>
+                        @endif
+                    @endforeach
 				</div>
 			</div>
 		@else

--- a/src/resources/views/language_tabs.blade.php
+++ b/src/resources/views/language_tabs.blade.php
@@ -1,0 +1,32 @@
+<ul class="nav nav-tabs " >
+    @foreach ($fileArray as $key => $item)
+        <li class="nav-item">
+            <a class="nav-link {{($key==$first_key ? 'active' : '')}}" data-toggle="tab" data-target="#{{$key}}">{{$key}}</a>
+        </li>
+    @endforeach
+</ul>
+<div class="tab-content">
+@foreach ($fileArray as $key => $item)
+        <div class="tab-pane {{($key==$first_key ? 'active' : '')}}"  id="{{$key}}">
+            @php
+                if (is_array($item)) {
+                    echo view()->make('langfilemanager::language_headers', [
+                        'header' => $key,
+                        'parents' => $parents,
+                        'level' => $level,
+                        'item' => $item,
+                        'langfile' => $langfile,
+                        'lang_file_name' => $lang_file_name,
+                    ])->render();
+                } else {
+                    echo view()->make('langfilemanager::language_inputs', [
+                        'key' => $key,
+                        'item' => $item,
+                        'parents' => $parents,
+                        'lang_file_name' => $lang_file_name,
+                    ])->render();
+                }
+            @endphp
+        </div>
+@endforeach
+</div>

--- a/src/resources/views/language_tabs.blade.php
+++ b/src/resources/views/language_tabs.blade.php
@@ -10,14 +10,7 @@
         <div class="tab-pane {{($key==$first_key ? 'active' : '')}}"  id="{{$key}}">
             @php
                 if (is_array($item)) {
-                    echo view()->make('langfilemanager::language_headers', [
-                        'header' => $key,
-                        'parents' => $parents,
-                        'level' => $level,
-                        'item' => $item,
-                        'langfile' => $langfile,
-                        'lang_file_name' => $lang_file_name,
-                    ])->render();
+                    echo $langfile->displayInputs($item, $parents, $header, $level);
                 } else {
                     echo view()->make('langfilemanager::language_inputs', [
                         'key' => $key,


### PR DESCRIPTION
Hi guys.
When I tried this package for the first time, I ran into the inconvenience of maintaining a lot of data
After a few months of working with the backpack, I decided to fix this issue and share with the community.

For nested arrays, tabs are created instead of a header, and  fill in multiple forms of the language also used to tabs for save space .
![image](https://user-images.githubusercontent.com/23197378/111885567-038b3100-89e2-11eb-9cff-4e0028c7633c.png)
![image](https://user-images.githubusercontent.com/23197378/111885977-71d0f300-89e4-11eb-8454-5543d40c26b2.png)

