### PR TITLE
Fixed regexp to display translatable strings

### DIFF
--- a/src/resources/views/language_inputs.blade.php
+++ b/src/resources/views/language_inputs.blade.php
@@ -22,7 +22,7 @@
 			<div style="margin-left: 15px;">
 			@foreach ($chuncks as $k => $chunck)
 				@php
-				preg_match('/^({\w}|\[[\w,]+\])([\w\s:]+)/', trim($chunck), $m);
+				preg_match('/^({\w}|\[[\w,*]+\])(.+)/', trim($chunck), $m);
 				@endphp
 				@if (empty($m))
 					<label for="{{ $chunck }}" class="col-sm-2 control-label">{{ (!$k ? trans('admin.language.singular') : trans('admin.language.plural')).":" }}</label>


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

before the update, the regular expression did not support such a string

"time_complete_quiz" => "{0}⏳first type|[1,*]⏳second type :time ",

### AFTER - What is happening after this PR?

`⏳first type` - this string is extracted correctly because now the regular expression is not only looking for letters and numbers

`[1,*]` - between square brackets, * symbol added (it is used in brackets according to Laravel specification)




### Is it a breaking change or non-breaking change?

non-breaking change



